### PR TITLE
Eliminate duplication, shift gen_server job.

### DIFF
--- a/src/riak_cs_control_helpers.erl
+++ b/src/riak_cs_control_helpers.erl
@@ -14,11 +14,12 @@
 
 -export([configure_s3_connection/0,
          administration_bucket_name/0,
-         strip_root_from_attributes/1,
+         strip_root_node/1,
          iso8601/1,
          cs_configuration/1]).
 
-strip_root_from_attributes(Attributes) ->
+%% @doc Remove root node from user structure.
+strip_root_node(Attributes) ->
     {struct, [{<<"user">>, DecodedAttributes}]} = mochijson2:decode(Attributes),
     mochijson2:encode(DecodedAttributes).
 

--- a/src/riak_cs_control_session.erl
+++ b/src/riak_cs_control_session.erl
@@ -61,19 +61,40 @@ init([]) ->
     {ok, #state{}}.
 
 handle_call(get_users, _From, State) ->
-    Response = get_request("users"),
+    Response = case get_request("users") of
+        {ok, Content} ->
+            parse_multipart_response(Content);
+        _ ->
+            []
+    end,
     {reply, {ok, Response}, State};
 
 handle_call({get_user, KeyId}, _From, State) ->
-    Response = get_request("user/" ++ KeyId),
+    Response = case get_request("user/" ++ KeyId) of
+        {ok, Content} ->
+            User = proplists:get_value(content, Content),
+            mochijson2:decode(User);
+        _ ->
+            {struct, []}
+    end,
     {reply, {ok, Response}, State};
 
 handle_call({put_user, Attributes}, _From, State) ->
-    Response = put_request("user", Attributes),
+    Response = case put_request("user", Attributes) of
+        {ok, {_Headers, Body}} ->
+            mochijson2:decode(Body);
+        _ ->
+            {struct, []}
+    end,
     {reply, {ok, Response}, State};
 
 handle_call({put_user, KeyId, Attributes}, _From, State) ->
-    Response = put_request("user/" ++ KeyId, Attributes),
+    Response = case put_request("user/" ++ KeyId, Attributes) of
+        {ok, {_Headers, Body}} ->
+            mochijson2:decode(Body);
+        _ ->
+            {struct, []}
+    end,
     {reply, {ok, Response}, State};
 
 handle_call(_Request, _From, State) ->
@@ -95,16 +116,58 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
+%% @doc Perform a put request to Riak CS.
 put_request(Url, Body) ->
-    erlcloud_s3:put_object(
-        riak_cs_control_helpers:administration_bucket_name(),
-        Url,
-        Body,
-        [{return_response, true}],
-        [{"content-type", "application/json"}]).
+    try
+        Response = erlcloud_s3:put_object(
+            riak_cs_control_helpers:administration_bucket_name(),
+            Url,
+            Body,
+            [{return_response, true}],
+            [{"content-type", "application/json"}]),
+        {ok, Response}
+    catch
+        error:Reason -> {error, Reason}
+    end.
 
+%% @doc Perform a get request to Riak CS.
 get_request(Url) ->
-    erlcloud_s3:get_object(
-        riak_cs_control_helpers:administration_bucket_name(),
-        Url,
-        [{accept, "application/json"}]).
+    try
+        Response = erlcloud_s3:get_object(
+            riak_cs_control_helpers:administration_bucket_name(),
+            Url,
+            [{accept, "application/json"}]),
+        {ok, Response}
+    catch
+        error:Reason -> {error, Reason}
+    end.
+
+%% @doc Strip leading carriage return and line feed so it's valid
+%% multipart/mixed (this is the body seperator which erlcloud is not
+%% properly handling).
+reformat_multipart(Content) ->
+    list_to_binary(string:substr(binary_to_list(Content), 3)).
+
+%% @doc Extract boundary from multipart header.
+extract_boundary(ContentType) ->
+    string:substr(ContentType, string:str(ContentType, "boundary=") +
+                  length("boundary=")).
+
+%% @doc Given a series of multipart documents, extract just body out and
+%% parse based on content type.
+parse_bodies(Parts) ->
+    [mochijson2:decode(Body) || {_Name, {_Params, _Headers}, Body} <- Parts].
+
+%% @doc Given a series of parsed JSON documents, merge.
+merge_bodies(Bodies) ->
+    lists:flatten(Bodies).
+
+%% @doc Parse multipart user response.
+parse_multipart_response(Response) ->
+    Content = proplists:get_value(content, Response),
+    ContentType = proplists:get_value(content_type, Response),
+    ModifiedContent = reformat_multipart(Content),
+    Boundary = extract_boundary(ContentType),
+    Parts = webmachine_multipart:get_all_parts(ModifiedContent, Boundary),
+    Bodies = parse_bodies(Parts),
+    merge_bodies(Bodies).


### PR DESCRIPTION
- Make sure the gen_server is responsible for all requests, catching for errors, and deserialization.
- Only encoding specific to the user/users web resources are wrapping in root-nodes which is specific only to the representation presented for the web.
