### PR TITLE
Bump the hash of erlydtl in the rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
 
 {deps, [
     {erlydtl, "0.7.0",
-     {git, "git://github.com/evanmiller/erlydtl.git", {tag, "c18f2a00"}}},
+     {git, "git://github.com/evanmiller/erlydtl.git", {tag, "6a9845f"}}},
     {node_package, "1.2.1",
       {git, "git://github.com/basho/node_package", {tag, "1.2.1"}}},
     {lager, ".*",


### PR DESCRIPTION
The current hash for erlydtl specified suffers from a regression. Update the
hash specified in the rebar.config file to a working version.
